### PR TITLE
Fix url for repositories

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -31,8 +31,8 @@ Create a `colcon workspace <https://colcon.readthedocs.io/en/released/user/quick
 
     mkdir ~/is-workspace
     cd ~/is-workspace
-    git clone ssh://git@github.com/eProsima/soss_v2 src/soss --recursive -b feature/xtypes-dds
-    git clone ssh://git@github.com/eProsima/SOSS-DDS src/soss-dds --recursive -b feature/xtypes-dds
+    git clone https://git@github.com/eProsima/soss_v2 src/soss --recursive -b feature/xtypes-dds
+    git clone https://git@github.com/eProsima/SOSS-DDS src/soss-dds --recursive -b feature/xtypes-dds
 
 .. note::
 


### PR DESCRIPTION
Cloning the repositories yields the following error:

```
 Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Switching to https instead works